### PR TITLE
スクロールの実装

### DIFF
--- a/Minge2023Summer_Team4/src/Game/oGameObject.cpp
+++ b/Minge2023Summer_Team4/src/Game/oGameObject.cpp
@@ -40,8 +40,8 @@ void GameObject::move()
 
 void GameObject::draw(Vec2 offset,bool isHitboxDraw) const
 {
-	this->texture.drawAt(offset);
-	if (isHitboxDraw) drawHitbox(offset);
+	this->texture.drawAt(-offset);
+	if (isHitboxDraw) drawHitbox(-offset);
 }
 
 
@@ -55,11 +55,11 @@ void GameObject::drawHitbox(Vec2 offset) const
 	debugfont(Format(hp)).drawAt(pos + offset + Vec2{0,30}, {Palette::Navy,0.5});
 }
 
-Figure GameObject::GetHitbox() {
+Figure GameObject::getHitbox() {
 	return hitbox;
 }
 
-int GameObject::GetDamage() {
+int GameObject::getDamage() {
 	return damage;
 }
 
@@ -76,4 +76,14 @@ void GameObject::onCollisionResponse(int damage)
 
 void GameObject::calcDamage(int damage)
 {
+}
+
+Vec2 GameObject::getPos() const
+{
+	return pos;
+}
+
+double GameObject::getSpeed() const
+{
+	return speed;
 }

--- a/Minge2023Summer_Team4/src/Game/oGameObject.h
+++ b/Minge2023Summer_Team4/src/Game/oGameObject.h
@@ -14,6 +14,7 @@ protected:
 
 	int hp = 0;
 	int damage = 1;
+	double speed;
 
 	Vec2 pos;
 	Vec2 Spd;
@@ -39,11 +40,14 @@ public:
 
 	virtual void draw(Vec2 offset, bool isHitboxDraw) const;
 
-	Figure GetHitbox();
-	int GetDamage();
 	bool isCollisional();
 	void onCollisionResponse(int damage);
 	void calcDamage(int damage);
 
+	//ゲッター関数
+	Vec2 getPos() const;
+	double getSpeed() const;
+	int getDamage();
+	Figure getHitbox();
 };
 

--- a/Minge2023Summer_Team4/src/Game/oPlayer.cpp
+++ b/Minge2023Summer_Team4/src/Game/oPlayer.cpp
@@ -50,6 +50,6 @@ void Player::move()
 
 void Player::draw(Vec2 offset, bool isHitboxDraw) const
 {
-	this->texture.scaled(0.5).drawAt(pos + offset);
-	if (isHitboxDraw) drawHitbox(offset);
+	this->texture.scaled(0.5).drawAt(pos - offset);
+	if (isHitboxDraw) drawHitbox(-offset);
 }

--- a/Minge2023Summer_Team4/src/Game/oPlayer.h
+++ b/Minge2023Summer_Team4/src/Game/oPlayer.h
@@ -6,9 +6,6 @@ class Player :
 {
 private:
 	const Texture texture{ U"💩"_emoji };
-	double speed;
-
-protected:
 
 public:
 	Player();

--- a/Minge2023Summer_Team4/src/Game/pGame.cpp
+++ b/Minge2023Summer_Team4/src/Game/pGame.cpp
@@ -7,11 +7,11 @@ Game::Game(const InitData& init)
 	
 	// 背景の色を設定 | Set background color
 	Scene::SetBackground(ColorF{ 0.8, 0.9, 1.0 });
-	
 
 	Print << U"Push [Q] key";
 
 	MouseCursor cursor;
+	topLeft = objectManager.myPlayer->getPos() - Scene::Center();
 }
 
 Game::~Game()
@@ -29,6 +29,7 @@ void Game::update()
 		changeScene(SceneList::Result);
 	}
 
+	scrollUpdate();
 	objectManager.update();
 	objectManager.collision();
 	debug();
@@ -41,13 +42,63 @@ void Game::draw() const
 	//従来のマウスカーソルを非表示に
 	Cursor::RequestStyle(CursorStyle::Hidden);
 
-	objectManager.draw();
-	TextureAsset(U"Frame").draw();
+	//objectManager.draw();
+	//TextureAsset(U"Frame").draw();
 	cursor.draw();
+	objectManager.draw(topLeft);
 }
 
 void Game::debug()
 {
+	ClearPrint();
 
+	//マップスクロール用
+	for (int32 i = 0; i < 100; ++i)
+	{
+		Circle{ -topLeft, (50 + i * 50) }.drawFrame(2);
+	}
+}
+
+void Game::scrollUpdate()
+{
+	//カメラ座標と左上座標の更新
+	cameraPos = objectManager.myPlayer->getPos();
+	topLeft = cameraPos - Scene::Center();
+
+	// X軸のステージの内外判定
+	if (cameraPos.x - Scene::Center().x <= 0.0f)
+	{
+		cameraPos.x = Scene::Center().x;
+	}
+	else if (cameraPos.x + Scene::Center().x >= FIELD_WIDTH)
+	{
+		cameraPos.x = FIELD_WIDTH - Scene::Center().x;
+	}
+
+	// Y軸のステージの内外判定
+	if (cameraPos.y - Scene::Center().y <= 0.0f)
+	{
+		cameraPos.y = Scene::Center().y;
+	}
+	else if (cameraPos.y + Scene::Center().y >= FIELD_HEIGHT)
+	{
+		cameraPos.y = FIELD_HEIGHT - Scene::Center().y;
+	}
+
+	cameraPos = convertToScreenPos(cameraPos);
+	topLeft = convertToScreenPos(topLeft);
 
 }
+
+Vec2 Game::convertToScreenPos(Vec2 pos)
+{
+
+	// カメラ座標からスクリーン座標の原点に変換する
+	Vec2 screenOriginPos = cameraPos - Scene::Center();
+
+	// ワールド座標からスクリーン座標に変換する
+	Vec2 screenPos = pos - screenOriginPos;
+
+	return screenPos;
+}
+

--- a/Minge2023Summer_Team4/src/Game/pGame.h
+++ b/Minge2023Summer_Team4/src/Game/pGame.h
@@ -9,6 +9,16 @@ private:
 	ObjectManager objectManager;
 	MouseCursor cursor;
 
+	//プレイヤーから見た相対的な左上座標
+	Vec2 topLeft;
+
+	//カメラ座標
+	Vec2 cameraPos;
+
+	//フィールドサイズ
+	const int FIELD_WIDTH = 10000000000;
+	const int FIELD_HEIGHT =10000000000;
+
 public:
 	Game(const InitData& init);
 	~Game();
@@ -18,4 +28,6 @@ public:
 
 	void debug();
 
+	void scrollUpdate();
+	Vec2 convertToScreenPos(Vec2 pos);
 };

--- a/Minge2023Summer_Team4/src/Game/pObjectManager.cpp
+++ b/Minge2023Summer_Team4/src/Game/pObjectManager.cpp
@@ -2,33 +2,33 @@
 
 ObjectManager::ObjectManager()
 {
-
+	myPlayer = new Player();
 }
 
 ObjectManager::~ObjectManager()
 {
-
+	delete myPlayer;
 }
 
 void ObjectManager::update()
 {
-	this->player.update();
+	this->myPlayer->update();
 	this->testdebris.update();
 }
 
 void ObjectManager::collision() {
-	if (this->player.isCollisional() == true) {
-		if (testdebris.isCollisional() && testdebris.GetHitbox().intersects(player.GetHitbox()))
+	if (this->myPlayer->isCollisional() == true) {
+		if (testdebris.isCollisional() && testdebris.getHitbox().intersects(myPlayer->getHitbox()))
 		{
-			player.onCollisionResponse(testdebris.GetDamage());
-			testdebris.onCollisionResponse(player.GetDamage());
+			myPlayer->onCollisionResponse(testdebris.getDamage());
+			testdebris.onCollisionResponse(myPlayer->getDamage());
 		}
 
 	}
 }
 
-void ObjectManager::draw() const
+void ObjectManager::draw(Vec2 offset) const
 {
-	this->testdebris.draw({ 0,0 }, true);
-	this->player.draw({0,0},true);
+	this->testdebris.draw(offset, true);
+	this->myPlayer->draw(offset, true);
 }

--- a/Minge2023Summer_Team4/src/Game/pObjectManager.h
+++ b/Minge2023Summer_Team4/src/Game/pObjectManager.h
@@ -7,14 +7,16 @@
 class ObjectManager
 {
 private:
-	Player player;
-	Debris testdebris{ { 200,200 }, { 100,50 } };
 
 public:
 	ObjectManager();
 	~ObjectManager();
 
+	Player* myPlayer;
+	Debris testdebris{ { 200,200 }, { 100,50 } };
+
+
 	void update();
 	void collision();
-	void draw() const;
+	void draw(Vec2 offset) const;
 };


### PR DESCRIPTION
やったこと

①pGameにtopLeft(左上座標)とscrollUpdate()とconvertToScreen(ワールド座標からスクリーン座標への変換)を作った。それにわせて、offsetの計算方式をちょっといじった（符号を変えただけ）

②プレイヤーのインスタンス化処理を変更。ポインタを使用して(Player* myPlayer)、pGameManagerのコンストラクタ内でnew、デストラクタでdeleteするように。あと変数名をmyPlayerに(enumのeObjectTypeと名前被りを避けるため)。こっちの方が処理が早くなるかも

③GameObjectにgetPos()、getSpeed()を追加。getSpeed()は実験とかで使っただけだから、今後いらなかったから消してもおけ。その他、GetDamageとかその辺の名前を変更。基本、関数名は小文字スタートで単語の区切りで大文字に。SpdとAccも変えたい（前者に関してはvelocityとかの方が適切かも）。