### PR TITLE
#67 debris clean update

### DIFF
--- a/Minge2023Summer_Team4/src/Game/oDebris.cpp
+++ b/Minge2023Summer_Team4/src/Game/oDebris.cpp
@@ -4,3 +4,11 @@ Debris::~Debris()
 {
 }
 
+bool Debris::isDead(Vec2 playerPos_) {
+	if ((pos - playerPos_).length() < 100) {
+		isItemDropable = false;
+		return true;
+	}
+	else if (hp <= 0) return true;
+	else return false;
+}

--- a/Minge2023Summer_Team4/src/Game/oDebris.cpp
+++ b/Minge2023Summer_Team4/src/Game/oDebris.cpp
@@ -5,7 +5,7 @@ Debris::~Debris()
 }
 
 bool Debris::isDead(Vec2 playerPos_) {
-	if ((pos - playerPos_).length() < 100) {
+	if ((pos - playerPos_).length() > 1800) {
 		isItemDropable = false;
 		return true;
 	}

--- a/Minge2023Summer_Team4/src/Game/oDebris.h
+++ b/Minge2023Summer_Team4/src/Game/oDebris.h
@@ -18,5 +18,7 @@ public:
 	};
 
 	~Debris();
+
+	bool isDead(Vec2 playerPos_ = { 0,0 });
 };
 

--- a/Minge2023Summer_Team4/src/Game/oGameObject.cpp
+++ b/Minge2023Summer_Team4/src/Game/oGameObject.cpp
@@ -109,6 +109,10 @@ bool GameObject::isDead(Vec2 playerPos_) {
 	else return false;
 }
 
+bool GameObject::isItemDrop() {
+	return isItemDropable;
+}
+
 //====================================================
 //君は完璧で最強のゲッター関数
 

--- a/Minge2023Summer_Team4/src/Game/oGameObject.h
+++ b/Minge2023Summer_Team4/src/Game/oGameObject.h
@@ -33,6 +33,9 @@ protected:
 	void updateCommon();
 	void drawHitbox(Vec2 offset) const;
 
+	//アイテムが落ちるかどうかの設定。HPが0になる意外の特殊死亡ではfalseになる。なおアイテムがドロップしないオブジェクトタイプでは参照されない。
+	bool isItemDropable = true;
+
 
 public:
 
@@ -55,6 +58,8 @@ public:
 	void changeCoolTime(Duration);
 
 	bool isDead(Vec2 playerPos_ = {0,0});
+	bool isItemDrop();
+	//実質ゲッター関数
 
 	//ゲッター関数
 	Vec2 getPos() const;

--- a/Minge2023Summer_Team4/src/Game/pObjectManager.cpp
+++ b/Minge2023Summer_Team4/src/Game/pObjectManager.cpp
@@ -59,7 +59,7 @@ void ObjectManager::collision() {
 	}
 
 	cleanUp(myPlayerBullets, myPlayer->getPos());
-	cleanUp(myDebrises);
+	cleanUp(myDebrises, myPlayer->getPos());
 	cleanUp(myEnemies);
 }
 

--- a/Minge2023Summer_Team4/src/Game/pObjectManager.h
+++ b/Minge2023Summer_Team4/src/Game/pObjectManager.h
@@ -106,6 +106,7 @@ void ObjectManager::cleanUp(Array<T*>& objs, Vec2 playerPos) {
 	{
 		if ((*it)->isDead(playerPos))
 		{
+			if ((*it)->isItemDrop() && (*it)->getObjType() == eObjectType::eDebris);// アイテム処理
 			delete* it;
 			it = objs.erase(it);
 		}
@@ -121,6 +122,7 @@ template<typename T>
 void ObjectManager::cleanUp(Array<T*>& objs) {
 	for (auto it = objs.begin(); it != objs.end();) {
 		if ((*it)->isDead()) {
+			if ((*it)->isItemDrop() && (*it)->getObjType() == eObjectType::eEnemy);// アイテム処理
 			delete* it;
 			it = objs.erase(it);
 		}


### PR DESCRIPTION
close #67 

デブリの範囲消滅を実装。消える距離はDebris.cpp内にマジックナンバーで記述されているので修正したいときはそこを確認されたし。

GameObject内にbool型変数のisItemDropableと、そのゲッター関数のbool isItemDrop()を実装（ゲッター関数と言っても直前に変わった値を調べにいくだけだしisDeadとやってること変わらない気がしてゲッター関数感がしなかった。なのでgetにしたくなくてこの名前にしました。変えたければ変えてくれ）